### PR TITLE
Fix distance problem when data are not sorted by date

### DIFF
--- a/Huawei-TCX-Converter.py
+++ b/Huawei-TCX-Converter.py
@@ -142,6 +142,9 @@ def read_file(input_file: str) -> dict:
                     holding_list[0] = _normalize_timestamp(holding_list[0])
                     data['alti'].append(holding_list)
 
+        # Sort GPS data by date for distance computation
+        data['gps'] = sorted(data['gps'], key=lambda x : x[0])
+
     except:
         print('FAILED')
         exit()


### PR DESCRIPTION
First, thank you very much for this project.
I encountered a problem of distance calculation with data comming from my watch Huawei Pro Band 3, distance was too big for being a normal run (36 millions of meters :smile: ).
Problem comes from GPS data in anarchic order.

The first commit just add a sort on GPS data for fixing this problem.

The second commit is more a cosmetic one, I added some variables in process_gps for clearness. Special GPS lost points (90, -80) are now always ignore, so distance computation isn't wrong anymore when one of these points is part of data