### PR TITLE
Ignore errors generating XML

### DIFF
--- a/Huawei-TCX-Converter.py
+++ b/Huawei-TCX-Converter.py
@@ -1316,7 +1316,11 @@ class TcxActivity:
     def save(self, tcx_filename: str = None):
         if not self.training_center_database:
             # Call generation of TCX XML date if not already done
-            self.generate_xml()
+            try:
+                self.generate_xml()
+            except Exception as e:
+                logging.info('Error generating XML for HiTrack activity <%s>\n%s', self.hi_activity.activity_id, e)
+                return
 
         # Format and save the TCX XML file
         if not tcx_filename:


### PR DESCRIPTION
Hi, I get a lot of errors when generating XML,
both from HiTrack files and from data export JSON

```
('Error generating TCX XML content for activity <%s>\n%s', 
'HiTrack_20191202_160031_155', 
TypeError("'NoneType' object is not subscriptable",))
``` 

Here is the fix to proceed generating all files available, needed when converting from JSON